### PR TITLE
Bugfix: Fixing LIN message parsing (reserved parameters)

### DIFF
--- a/src/Vector/BLF/File.cpp
+++ b/src/Vector/BLF/File.cpp
@@ -716,7 +716,7 @@ void File::uncompressedFile2ReadWriteQueue() {
 
     int32_t tmp = 0;
     if (obj->calculateObjectSize() > ohb.objectSize) {
-	// we are about to read too much data
+        // we are about to read too much data
         tmp = ohb.objectSize - obj->calculateObjectSize();
     }
 

--- a/src/Vector/BLF/File.cpp
+++ b/src/Vector/BLF/File.cpp
@@ -714,11 +714,21 @@ void File::uncompressedFile2ReadWriteQueue() {
         throw Exception("File::uncompressedFile2ReadWriteQueue(): Unknown object.");
     }
 
+    int32_t tmp = 0;
+    if (obj->calculateObjectSize() > ohb.objectSize) {
+	// we are about to read too much data
+        tmp = ohb.objectSize - obj->calculateObjectSize();
+    }
+
     /* read object */
     obj->read(m_uncompressedFile);
     if (!m_uncompressedFile.good()) {
         delete obj;
         throw Exception("File::uncompressedFile2ReadWriteQueue(): Read beyond end of file.");
+    }
+
+    if (tmp!=0) {
+        m_uncompressedFile.seekg(tmp);
     }
 
     /* push data into readWriteQueue */

--- a/src/Vector/BLF/LinMessage.cpp
+++ b/src/Vector/BLF/LinMessage.cpp
@@ -41,7 +41,12 @@ void LinMessage::read(AbstractFile & is) {
     is.read(reinterpret_cast<char *>(&crc), sizeof(crc));
     is.read(reinterpret_cast<char *>(&dir), sizeof(dir));
     is.read(reinterpret_cast<char *>(&reservedLinMessage1), sizeof(reservedLinMessage1));
-    is.read(reinterpret_cast<char *>(&reservedLinMessage2), sizeof(reservedLinMessage2));
+
+    reservedLinMessage2_present = false;
+    if (this->objectSize >= calculateObjectSize() + sizeof(reservedLinMessage2)) {
+        is.read(reinterpret_cast<char *>(&reservedLinMessage2), sizeof(reservedLinMessage2));
+        reservedLinMessage2_present = true;
+    }
 }
 
 void LinMessage::write(AbstractFile & os) {
@@ -74,7 +79,7 @@ uint32_t LinMessage::calculateObjectSize() const {
         sizeof(crc) +
         sizeof(dir) +
         sizeof(reservedLinMessage1) +
-        sizeof(reservedLinMessage2);
+        (reservedLinMessage2_present ? sizeof(reservedLinMessage2) : 0);
 }
 
 }

--- a/src/Vector/BLF/LinMessage.h
+++ b/src/Vector/BLF/LinMessage.h
@@ -114,6 +114,7 @@ struct VECTOR_BLF_EXPORT LinMessage final : ObjectHeader {
     uint8_t reservedLinMessage1 {};
 
     /** reserved */
+    bool reservedLinMessage2_present{};
     uint32_t reservedLinMessage2 {};
 };
 

--- a/src/Vector/BLF/LinSendError2.cpp
+++ b/src/Vector/BLF/LinSendError2.cpp
@@ -39,8 +39,13 @@ void LinSendError2::read(AbstractFile & is) {
     is.read(reinterpret_cast<char *>(&reservedLinSendError2), sizeof(reservedLinSendError2));
     is.read(reinterpret_cast<char *>(&exactHeaderBaudrate), sizeof(exactHeaderBaudrate));
     is.read(reinterpret_cast<char *>(&earlyStopbitOffset), sizeof(earlyStopbitOffset));
-    is.read(reinterpret_cast<char *>(&reservedLinSendError3), sizeof(reservedLinSendError3));
-    // @note might be extended in future versions
+
+    reservedLinSendError3_present = false;
+    if (this->objectSize >= calculateObjectSize() + sizeof(reservedLinSendError3)) {
+        is.read(reinterpret_cast<char*>(&reservedLinSendError3), sizeof(reservedLinSendError3));
+        reservedLinSendError3_present = true;
+	// @note might be extended in future versions
+    }
 }
 
 void LinSendError2::write(AbstractFile & os) {
@@ -69,7 +74,7 @@ uint32_t LinSendError2::calculateObjectSize() const {
         sizeof(reservedLinSendError2) +
         sizeof(exactHeaderBaudrate) +
         sizeof(earlyStopbitOffset) +
-        sizeof(reservedLinSendError3);
+        (reservedLinSendError3_present ? sizeof(reservedLinSendError3) : 0);
 }
 
 }

--- a/src/Vector/BLF/LinSendError2.h
+++ b/src/Vector/BLF/LinSendError2.h
@@ -100,6 +100,7 @@ struct VECTOR_BLF_EXPORT LinSendError2 final : ObjectHeader, LinMessageDescripto
     uint32_t earlyStopbitOffset {};
 
     /** reserved */
+    bool reservedLinSendError3_present{};
     uint32_t reservedLinSendError3 {};
 };
 


### PR DESCRIPTION
Some LIN messages were assuming that reserved parameters were present
without checking the object length. So they read to far.
This patch fixes this for LinMessage and LinSendError2.
It also adds a generic patch that would seek back, when
this happends in additional formats.